### PR TITLE
fix: add custom hook to post form submissions to netlify

### DIFF
--- a/src/components/EmailModal/EmailModal.tsx
+++ b/src/components/EmailModal/EmailModal.tsx
@@ -1,7 +1,7 @@
 import { Button, Group, Image, Modal, Stack, Text, TextInput, Title } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { useDisclosure } from '@mantine/hooks';
-import { notifications } from '@mantine/notifications';
+import { useCustomSubmit } from '@/hooks/useCustomSubmit';
 import image from './image.svg';
 import classes from './EmailModal.module.css';
 import notificationStyle from './notifications.module.css';
@@ -20,30 +20,7 @@ function EmailModal() {
       email: (val) => (/^\S+@\S+$/.test(val) ? null : 'Invalid email'),
     },
   });
-
-  const validatedSubmit = () => {
-    notifications.show({
-      color: 'green',
-      title: 'Message Sent',
-      message: 'Your message has been sent, we will contact you soon :)',
-      classNames: notificationStyle,
-      position: 'top-center',
-      pos: 'fixed',
-    });
-    form.reset();
-    close();
-  };
-
-  const errorSubmit = () => {
-    notifications.show({
-      color: 'red',
-      title: 'Message Failed',
-      message: 'Please correct errors and send again :(',
-      position: 'top-center',
-      classNames: notificationStyle,
-      pos: 'absolute',
-    });
-  };
+  const customSubmit = useCustomSubmit(form, notificationStyle);
 
   return (
     <>
@@ -68,7 +45,7 @@ function EmailModal() {
               method="POST" // Added for Netlify form submission
               data-netlify="true" // Enables Netlify Forms
               netlify-honeypot="bot-field" // Adds a honeypot field for spam prevention
-              onSubmit={form.onSubmit(validatedSubmit, errorSubmit)} // Kept your original onSubmit handler
+              onSubmit={customSubmit} // Kept your original onSubmit handler
             >
               {/* Hidden input for Netlify form name */}
               <input type="hidden" name="form-name" value="email-modal" />

--- a/src/components/GetInTouch/GetInTouch.tsx
+++ b/src/components/GetInTouch/GetInTouch.tsx
@@ -11,15 +11,13 @@ import {
   TextInput,
 } from '@mantine/core';
 import { useForm } from '@mantine/form';
-import { notifications } from '@mantine/notifications';
-import { useNavigateToTop } from '@/hooks/useNavigateToTop';
+import { useCustomSubmit } from '@/hooks/useCustomSubmit';
 import { ContactIconsList } from './ContactIcons';
 import pattern from './polygon.svg';
 import classes from './GetInTouch.module.css';
 import notificationStyle from './notifications.module.css';
 
 export function GetInTouch() {
-  const navigate = useNavigateToTop();
   const form = useForm({
     mode: 'uncontrolled',
     initialValues: { name: '', email: '', subject: '', message: '' },
@@ -32,30 +30,7 @@ export function GetInTouch() {
         value.length < 25 ? 'Message must have at least 25 letters' : null,
     },
   });
-
-  const validatedSubmit = () => {
-    notifications.show({
-      color: 'green',
-      title: 'Message Sent',
-      message: 'Your message has been sent, we will contact you soon :)',
-      classNames: notificationStyle,
-      position: 'top-center',
-      pos: 'fixed',
-    });
-    form.reset();
-    navigate('/', 'instant');
-  };
-
-  const errorSubmit = () => {
-    notifications.show({
-      color: 'red',
-      title: 'Message Failed',
-      message: 'Please correct errors and send again :(',
-      position: 'top-center',
-      classNames: notificationStyle,
-      pos: 'absolute',
-    });
-  };
+  const customSubmit = useCustomSubmit(form, notificationStyle);
 
   return (
     <Container className={classes.outter}>
@@ -76,7 +51,8 @@ export function GetInTouch() {
             method="POST"
             data-netlify="true" // Enables Netlify Forms
             netlify-honeypot="bot-field" // Optional: Adds a honeypot field for spam protection
-            onSubmit={form.onSubmit(validatedSubmit, errorSubmit)}
+            onSubmit={customSubmit}
+            action="/"
           >
             {/* Hidden input for form name */}
             <input type="hidden" name="form-name" value="contact" />

--- a/src/hooks/useCustomSubmit.ts
+++ b/src/hooks/useCustomSubmit.ts
@@ -1,0 +1,48 @@
+import { useNavigate } from 'react-router-dom';
+import { notifications } from '@mantine/notifications';
+
+export const useCustomSubmit = (form: any, notificationStyle: any) => {
+  const navigate = useNavigate();
+
+  const customSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const validation = form.validate();
+    if (!validation.hasErrors) {
+      const formData = new FormData(event.currentTarget);
+      try {
+        await fetch('/', {
+          method: 'POST',
+          body: formData,
+        });
+        notifications.show({
+          color: 'green',
+          title: 'Message Sent',
+          message: 'Your message has been sent, we will contact you soon :)',
+          classNames: notificationStyle,
+          position: 'top-center',
+          pos: 'fixed',
+        });
+        form.reset();
+        navigate('/', { replace: true });
+      } catch (error) {
+        notifications.show({
+          color: 'red',
+          title: 'Submission Error',
+          message: 'There was a problem submitting the form. Please try again.',
+          position: 'top-center',
+          classNames: notificationStyle,
+        });
+      }
+    } else {
+      notifications.show({
+        color: 'red',
+        title: 'Message Failed',
+        message: 'Please correct errors and send again :(',
+        position: 'top-center',
+        classNames: notificationStyle,
+      });
+    }
+  };
+
+  return customSubmit;
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add custom hook to handle form submissions. The mantine useForm was causing form submission issues. The hook now does a post request directly to netlify to submit the form. I may handle this on the backend later. 
## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
